### PR TITLE
Extract logic from services into common method

### DIFF
--- a/eventbrite/services/Eventbrite_BaseService.php
+++ b/eventbrite/services/Eventbrite_BaseService.php
@@ -47,6 +47,13 @@ class Eventbrite_BaseService extends BaseApplicationComponent
 		return $this->pop_from_array($options, 'id');
 	}
 
+  protected function _get($endpoint, $options){
+    $query    = http_build_query($options);
+    $url      = $this->_buildEventbriteUrl($endpoint) . $query;
+    $response = $this->_makeRequest($url);
+    return $response;
+  }
+
 	public function pop_from_array(&$array, $key, $default = null)
 	{
 		if (array_key_exists($key, $array)) {

--- a/eventbrite/services/Eventbrite_UsersService.php
+++ b/eventbrite/services/Eventbrite_UsersService.php
@@ -3,30 +3,24 @@ namespace Craft;
 
 class Eventbrite_UsersService extends Eventbrite_BaseService
 {
-	public function getUser($options = array())
-	{
-		$id = $this->_getIdFromOptions($options);
-		$query = http_build_query($options);
-		$url = $this->_buildEventbriteUrl('users/' . $id . '/') . $query;
-		$response = $this->_makeRequest($url);
-		return $response;
-	}
+  public function getUser($options = array())
+  {
+    $id       = $this->_getIdFromOptions($options);
+    $response = $this->_get('users/' . $id . '/', $options);
+    return $response;
+  }
 
-	public function getOwnedEvents($options = array())
-	{
-		$id = $this->_getIdFromOptions($options);
-		$query = http_build_query($options);
-		$url = $this->_buildEventbriteUrl('users/' . $id . '/owned_events/') . $query;
-		$response = $this->_makeRequest($url);
-		return $response['events'];
-	}
+  public function getOwnedEvents($options = array())
+  {
+    $id       = $this->_getIdFromOptions($options);
+    $response = $this->_get('users/' . $id . '/owned_events/', $options);
+    return $response['events'];
+  }
 
-	public function getEvents($options = array())
-	{
-		$id = $this->_getIdFromOptions($options);
-		$query = http_build_query($options);
-		$url = $this->_buildEventbriteUrl('users/' . $id . '/events/') . $query;
-		$response = $this->_makeRequest($url);
-		return $response['events'];
-	}
+  public function getEvents($options = array())
+  {
+    $id       = $this->_getIdFromOptions($options);
+    $response = $this->_get('users/' . $id . '/events/', $options);
+    return $response['events'];
+  }
 }

--- a/eventbrite/services/Eventbrite_VenuesService.php
+++ b/eventbrite/services/Eventbrite_VenuesService.php
@@ -3,12 +3,10 @@ namespace Craft;
 
 class Eventbrite_VenuesService extends Eventbrite_BaseService
 {
-	public function getVenue($options = array())
-	{
-		$id = $this->_getIdFromOptions($options);
-		$query = http_build_query($options);
-		$url = $this->_buildEventbriteUrl('venues/' . $id . '/') . $query;
-		$response = $this->_makeRequest($url);
-		return $response;
-	}
+  public function getVenue($options = array())
+  {
+    $id       = $this->_getIdFromOptions($options);
+    $response = $this->_get('venues/' . $id . '/', $options);
+    return $response;
+  }
 }


### PR DESCRIPTION
Same logic happens, just extracted some common code to the base class. This is untested, so you probably want to pull it down and test it before merging (if you do merge it).

Just some refactoring thoughts. Feel free to close if you deem it unnecessary.

You could go even further and remove the `_getIdFromOptions` method completely and just use the `me` string - but I imagine you did that to support the ability to query various users in the future, so I didn't mess with that.

Everything else looks rock solid. Nice work :+1: 

EDIT: You'll also want to add hard-tabs back in, since my editor removes them.
